### PR TITLE
Fix KeyError if tienda not read

### DIFF
--- a/leer_estado_juego.py
+++ b/leer_estado_juego.py
@@ -4,6 +4,10 @@ from leer_ronda_automatica import detectar_ronda as obtener_ronda
 from leer_oro_automatico import detectar_oro
 from detectar_sinergias import detectar_sinergias_activas
 
+# El código original no contemplaba la lectura de la tienda ni el banco.
+# Para evitar errores en módulos que esperan estas claves, se devolverán
+# listas vacías por defecto.
+
 
 def leer_estado_juego():
     """
@@ -32,6 +36,12 @@ def leer_estado_juego():
     except Exception as e:
         estado["oro"] = None
         print(f"[ERROR] No se pudo leer el oro: {e}")
+
+    # Claves opcionales utilizadas por otros módulos.
+    # Se devuelven listas vacías para evitar KeyError si aún no se ha
+    # implementado la detección automática de la tienda o del banco.
+    estado.setdefault("tienda", [])
+    estado.setdefault("banco", [])
 
     return estado
 

--- a/leer_oro_automatico.py
+++ b/leer_oro_automatico.py
@@ -46,5 +46,21 @@ def capturar_y_leer_oro():
     else:
         print("[✘] No se detectó ningún número.")
 
+
+def detectar_oro():
+    """Captura la zona de oro y devuelve el valor detectado.
+
+    Esta función actúa como un pequeño wrapper para ``capturar_y_leer_oro`` pero
+    retornando únicamente el número obtenido en lugar de imprimirlo por
+    pantalla.
+    """
+    x, y, w, h = 1205, 580, 80, 40  # Coordenadas ajustables
+    captura = pyautogui.screenshot(region=(x, y, w, h))
+    ruta_imagen = "frame_oro.png"
+    captura.save(ruta_imagen)
+
+    texto = leer_oro_desde_imagen(ruta_imagen)
+    return int(texto) if texto.isdigit() else None
+
 if __name__ == "__main__":
     capturar_y_leer_oro()


### PR DESCRIPTION
## Summary
- default to empty tienda/banco values in `leer_estado_juego`

## Testing
- `python -m py_compile leer_oro_automatico.py leer_estado_juego.py main_loop.py`
- (failure) `python main_loop.py -n 1 -o test.json` *(missing pyautogui in env)*

------
https://chatgpt.com/codex/tasks/task_b_6859670fae3083308a50bfb03674e5b1