### PR TITLE
Fix gold fallback in modelo_ia

### DIFF
--- a/modelo_ia.py
+++ b/modelo_ia.py
@@ -24,7 +24,8 @@ else:
 modelo.eval()
 
 def decision_ia(estado):
-    oro = estado["oro"]
+    # Usar 0 si el oro no está disponible o es None
+    oro = estado.get("oro", 0) or 0
     tienda = [heroes_id.get(h, 0) for h in estado["tienda"]]
     tienda += [0] * (5 - len(tienda))  # Rellenar si hay menos de 5
 
@@ -69,7 +70,8 @@ def decision_ia(estado):
     return decisiones
 
 def decision_ia_con_modelo(estado, modelo):
-    oro = estado["oro"]
+    # Usar 0 si el oro no está disponible o es None
+    oro = estado.get("oro", 0) or 0
     tienda = [heroes_id.get(h, 0) for h in estado["tienda"]]
     tienda += [0] * (5 - len(tienda))
 


### PR DESCRIPTION
## Summary
- handle missing gold in decision_ia and decision_ia_con_modelo
- keep vector input consistent when `oro` is absent

## Testing
- `python -m py_compile modelo_ia.py`

------
https://chatgpt.com/codex/tasks/task_b_685990c64eb08330aae8b205702c1b9a