### PR TITLE
Add .gitignore for build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+__pycache__/
+*.pyc
+.DS_Store
+# Temporary images
+*.png
+# Generated JSON data
+*.json


### PR DESCRIPTION
## Summary
- add .gitignore to exclude caches, compiled Python files, macOS metadata, temporary images and JSON files

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685992ce16e08330901595a563b43b75