### PR TITLE
Add automatic reporting

### DIFF
--- a/autoentrenar_continuo.py
+++ b/autoentrenar_continuo.py
@@ -6,6 +6,7 @@ from entrenar_modelo import entrenar_modelo
 from simulador import simular_rondas
 from pathlib import Path
 from shutil import copyfile
+from generar_reporte import generar_reporte
 
 ARCHIVO_DATOS = "partida_simulada.json"
 BACKUP_DIR = "backups"
@@ -84,5 +85,6 @@ while True:
         os.remove(backups[0])
         backups.pop(0)
 
+    generar_reporte()
     ciclo += 1
     time.sleep(1)  # espera 1 segundo entre ciclos para evitar sobrecarga

--- a/generar_reporte.py
+++ b/generar_reporte.py
@@ -1,0 +1,55 @@
+import os
+import json
+import pandas as pd
+import matplotlib.pyplot as plt
+
+
+def generar_reporte(archivo_datos="partida_simulada.json", winrate_log="winrate_por_ciclo.txt", salida_dir="graficas"):
+    os.makedirs(salida_dir, exist_ok=True)
+
+    # Winrate trends
+    if os.path.exists(winrate_log):
+        try:
+            df_win = pd.read_csv(winrate_log, names=["ciclo", "winrate"])
+            plt.figure()
+            plt.plot(df_win["ciclo"], df_win["winrate"], marker="o")
+            plt.title("Winrate por ciclo")
+            plt.xlabel("Ciclo")
+            plt.ylabel("Winrate (%)")
+            plt.grid(True)
+            plt.tight_layout()
+            plt.savefig(os.path.join(salida_dir, "winrate_trend.png"))
+            plt.close()
+        except Exception as e:
+            print(f"Error al generar grafico de winrate: {e}")
+
+    # Synergy usage
+    if os.path.exists(archivo_datos):
+        try:
+            with open(archivo_datos, encoding="utf-8") as f:
+                datos = json.load(f)
+        except Exception as e:
+            print(f"Error al leer {archivo_datos}: {e}")
+            datos = []
+
+        conteo = {}
+        for ronda in datos:
+            for sin, val in ronda.get("sinergias", {}).items():
+                conteo[sin] = conteo.get(sin, 0) + val
+
+        if conteo:
+            df_sin = pd.DataFrame(list(conteo.items()), columns=["sinergia", "uso"])
+            df_sin.sort_values("uso", ascending=False, inplace=True)
+            csv_path = os.path.join(salida_dir, "sinergias.csv")
+            df_sin.to_csv(csv_path, index=False)
+
+            plt.figure(figsize=(8, 4))
+            plt.bar(df_sin["sinergia"], df_sin["uso"])
+            plt.title("Uso de sinergias")
+            plt.ylabel("Apariciones")
+            plt.xticks(rotation=45, ha="right")
+            plt.tight_layout()
+            plt.savefig(os.path.join(salida_dir, "sinergias.png"))
+            plt.close()
+
+


### PR DESCRIPTION
## Summary
- add `generar_reporte.py` helper to plot winrate trends and synergy counts
- call the new helper after each auto-training cycle

## Testing
- `python -m py_compile autoentrenar_continuo.py generar_reporte.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6859981d8eec8330a0659c3a884dce07