### PR TITLE
Add I/O backend abstraction

### DIFF
--- a/config.py
+++ b/config.py
@@ -6,3 +6,7 @@ SINERGIAS_FIJAS = [
     "Mage", "Elementalist", "Assassin", "Mecha", "Undead",
     "Wrestler", "Elf", "Dragon"
 ]
+
+# Modo de interacción para entrada/salida.
+# "desktop" usa pyautogui local, "mobile" utiliza ADB.
+IO_MODE = "desktop"

--- a/detectar_sinergias.py
+++ b/detectar_sinergias.py
@@ -1,7 +1,7 @@
 """Detección de sinergias usando el detector de objetos."""
 
 import cv2
-import pyautogui
+import io_backend
 import json
 import os
 
@@ -31,7 +31,7 @@ def _ensure_detector():
 def detectar_sinergias_activas():
     _ensure_detector()
     etiquetas = cargar_etiquetas()
-    captura = pyautogui.screenshot()
+    captura = io_backend.screenshot()
     resultados = detect(_detector, captura, 0.4)
     activas = []
     for label, box, score in resultados:

--- a/io_backend.py
+++ b/io_backend.py
@@ -1,0 +1,57 @@
+import io
+import subprocess
+from PIL import Image
+
+import config
+
+if config.IO_MODE == "desktop":
+    import pyautogui
+else:
+    pyautogui = None
+
+
+def screenshot(region=None):
+    """Return a PIL image of the current screen.
+
+    For desktop mode this delegates to ``pyautogui.screenshot``. In mobile
+    mode it captures the screen using ``adb exec-out screencap`` and optionally
+    crops to the given region (x, y, width, height).
+    """
+    if config.IO_MODE == "desktop":
+        return pyautogui.screenshot(region=region)
+    elif config.IO_MODE == "mobile":
+        result = subprocess.run([
+            "adb",
+            "exec-out",
+            "screencap",
+            "-p",
+        ], stdout=subprocess.PIPE, check=True)
+        img = Image.open(io.BytesIO(result.stdout))
+        if region:
+            x, y, w, h = region
+            img = img.crop((x, y, x + w, y + h))
+        return img
+    else:
+        raise ValueError(f"Unsupported IO_MODE: {config.IO_MODE}")
+
+
+def tap(x, y):
+    """Simulate a screen tap/click at the given coordinates."""
+    if config.IO_MODE == "desktop":
+        pyautogui.click(x, y)
+    elif config.IO_MODE == "mobile":
+        subprocess.run([
+            "adb",
+            "shell",
+            "input",
+            "tap",
+            str(int(x)),
+            str(int(y)),
+        ], check=True)
+    else:
+        raise ValueError(f"Unsupported IO_MODE: {config.IO_MODE}")
+
+
+click = tap
+
+__all__ = ["screenshot", "tap", "click"]

--- a/leer_oro_automatico.py
+++ b/leer_oro_automatico.py
@@ -1,6 +1,6 @@
 """Lectura automática del oro usando un detector de objetos."""
 
-import pyautogui
+import io_backend
 import pytesseract
 from PIL import Image
 import cv2
@@ -49,7 +49,7 @@ def _ensure_detector():
 def capturar_y_leer_oro():
     """Captura la pantalla completa y detecta la región del oro."""
     _ensure_detector()
-    captura = pyautogui.screenshot()
+    captura = io_backend.screenshot()
     resultados = detect(_detector, captura, 0.4)
     bbox = next((b for l, b, s in resultados if l == "oro"), None)
 

--- a/leer_ronda_automatica.py
+++ b/leer_ronda_automatica.py
@@ -3,7 +3,7 @@
 import cv2
 import pytesseract
 import re
-import pyautogui
+import io_backend
 import numpy as np
 
 from detection import load_detector, detect
@@ -32,7 +32,7 @@ def _ensure_detector():
 
 def detectar_ronda():
     _ensure_detector()
-    screenshot = pyautogui.screenshot()
+    screenshot = io_backend.screenshot()
     resultados = detect(_detector, screenshot, 0.4)
     bbox = next((b for l, b, s in resultados if l == "ronda"), None)
     if bbox is None:

--- a/main_loop.py
+++ b/main_loop.py
@@ -1,0 +1,1 @@
+import io_backend


### PR DESCRIPTION
## Summary
- add io_backend module to handle screenshots and taps via IO_MODE
- support desktop and mobile (adb) modes
- update config with IO_MODE setting
- refactor modules to import io_backend

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6859abea7e4c8330852b42b515b44bde