### PR TITLE
Improve adb error handling

### DIFF
--- a/detectar_sinergias.py
+++ b/detectar_sinergias.py
@@ -32,6 +32,8 @@ def detectar_sinergias_activas():
     _ensure_detector()
     etiquetas = cargar_etiquetas()
     captura = io_backend.screenshot()
+    if captura is None:
+        return []
     resultados = detect(_detector, captura, 0.4)
     activas = []
     for label, box, score in resultados:

--- a/leer_oro_automatico.py
+++ b/leer_oro_automatico.py
@@ -50,6 +50,8 @@ def capturar_y_leer_oro():
     """Captura la pantalla completa y detecta la región del oro."""
     _ensure_detector()
     captura = io_backend.screenshot()
+    if captura is None:
+        return None
     resultados = detect(_detector, captura, 0.4)
     bbox = next((b for l, b, s in resultados if l == "oro"), None)
 

--- a/leer_ronda_automatica.py
+++ b/leer_ronda_automatica.py
@@ -33,6 +33,8 @@ def _ensure_detector():
 def detectar_ronda():
     _ensure_detector()
     screenshot = io_backend.screenshot()
+    if screenshot is None:
+        return None
     resultados = detect(_detector, screenshot, 0.4)
     bbox = next((b for l, b, s in resultados if l == "ronda"), None)
     if bbox is None:


### PR DESCRIPTION
## Summary
- handle adb failures in `io_backend` screenshot and tap
- guard screenshot callers against `None`

## Testing
- `python -m py_compile io_backend.py leer_oro_automatico.py leer_ronda_automatica.py detectar_sinergias.py`
- `python test_vector.py`
- `python test.py`


------
https://chatgpt.com/codex/tasks/task_b_6859adf0a8208330a076b9f2730d4b96