### PR TITLE
Refactor tienda utils to use io_backend

### DIFF
--- a/io_backend.py
+++ b/io_backend.py
@@ -75,4 +75,33 @@ def tap(x, y):
 
 click = tap
 
-__all__ = ["screenshot", "tap", "click", "ADBError"]
+def press(key: str):
+    """Simulate a key press."""
+    if config.IO_MODE == "desktop":
+        pyautogui.press(key)
+    elif config.IO_MODE == "mobile":
+        if len(key) == 1 and key.isalpha():
+            keyevent = f"KEYCODE_{key.upper()}"
+        else:
+            keyevent = str(key)
+        try:
+            subprocess.run([
+                "adb",
+                "shell",
+                "input",
+                "keyevent",
+                keyevent,
+            ], check=True)
+        except FileNotFoundError:
+            msg = "[ADB ERROR] 'adb' command not found. Check your adb installation and connection."
+            print(msg)
+            raise ADBError(msg)
+        except subprocess.CalledProcessError:
+            msg = "[ADB ERROR] Failed to send keyevent command. Ensure a device is connected and authorized."
+            print(msg)
+            raise ADBError(msg)
+    else:
+        raise ValueError(f"Unsupported IO_MODE: {config.IO_MODE}")
+
+
+__all__ = ["screenshot", "tap", "click", "press", "ADBError"]

--- a/tienda_utils.py
+++ b/tienda_utils.py
@@ -1,18 +1,33 @@
 import time
-import pyautogui
-from PIL import ImageStat
+
+import io_backend
+from detection import load_detector, is_shop_visible
+
 
 # Región donde debería verse el botón/área de la tienda. Las coordenadas son
 # aproximadas y pueden ajustarse según la resolución utilizada.
 SHOP_BUTTON_REGION = (620, 640, 80, 80)
 
+_detector = None
+
+
+def _ensure_detector():
+    global _detector
+    if _detector is None:
+        _detector = load_detector("detector.pth")
+
 
 def tienda_presente():
     """Devuelve ``True`` si se detecta el botón de la tienda en pantalla."""
+    _ensure_detector()
     try:
-        captura = pyautogui.screenshot(region=SHOP_BUTTON_REGION)
-        brillo = ImageStat.Stat(captura.convert("L")).mean[0]
-        return brillo > 30
+        captura = io_backend.screenshot(region=SHOP_BUTTON_REGION)
+        if captura is None:
+            return False
+        return is_shop_visible(_detector, captura)
+    except io_backend.ADBError as exc:
+        print(f"[ADB ERROR] {exc}")
+        return False
     except Exception as exc:
         print(f"[ERROR] No se pudo verificar la tienda: {exc}")
         return False
@@ -20,5 +35,8 @@ def tienda_presente():
 
 def abrir_tienda():
     """Envía un atajo de teclado para intentar abrir la tienda."""
-    pyautogui.press("b")
+    try:
+        io_backend.press("b")
+    except io_backend.ADBError as exc:
+        print(f"[ADB ERROR] {exc}")
     time.sleep(0.5)


### PR DESCRIPTION
## Summary
- add `press` helper to `io_backend`
- swap direct pyautogui calls in `tienda_utils` with `io_backend` wrappers
- detect shop button with `detection.is_shop_visible`
- handle adb failures gracefully

## Testing
- `python -m py_compile io_backend.py tienda_utils.py`
- `python test.py`

------
https://chatgpt.com/codex/tasks/task_b_6859b21d4a108330aa989a0020ae6ad9