### PR TITLE
Fix imports in leer_oro_desde_imagen

### DIFF
--- a/leer_oro_automatico.py
+++ b/leer_oro_automatico.py
@@ -14,10 +14,6 @@ _detector = None
 
 
 def leer_oro_desde_imagen(ruta):
-    import cv2
-    import pytesseract
-    import numpy as np
-
     imagen = cv2.imread(ruta)
     
     # Aumentar tamaño


### PR DESCRIPTION
## Summary
- remove inner imports from `leer_oro_desde_imagen`

## Testing
- `python -m py_compile leer_oro_automatico.py`


------
https://chatgpt.com/codex/tasks/task_b_6859b30ce90c8330bc1267af45341238