### PR TITLE
Add hero detection for shop and bench

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,11 +145,13 @@ Con el tiempo, la IA **maximiza su recompensa**.
 
 1. Coloca tus capturas anotadas en `dataset/images` y las
    anotaciones en `dataset/annotations.json` (formato simple).
+   Ahora se admiten clases adicionales para **cada héroe en tienda** y
+   **las unidades del banco**.
 2. Ejecuta `python detection.py` con la función `train_detector` para
-   generar `detector.pth`.
-3. Los módulos `leer_oro_automatico.py`, `leer_ronda_automatica.py` y
-   `detectar_sinergias.py` usarán ese modelo para localizar cada
-   elemento sin depender de la resolución.
+   generar `detector.pth` con todas estas clases.
+3. Los módulos `leer_oro_automatico.py`, `leer_ronda_automatica.py`,
+   `detectar_sinergias.py` y `leer_estado_juego.py` usarán ese modelo
+   para localizar cada elemento sin depender de la resolución.
 
 ---
 


### PR DESCRIPTION
## Summary
- expand object detector labels to include each hero and provide helper to get shop & bench
- detect heroes in `leer_estado_juego` using the new detector
- note new training classes in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python test.py`
- `python test_vector.py`


------
https://chatgpt.com/codex/tasks/task_b_6859b51626288330bc0eb99c8661226c