### PR TITLE
Fix duplicate heroes_id import

### DIFF
--- a/preparar_datos.py
+++ b/preparar_datos.py
@@ -1,6 +1,5 @@
 import json
-
-from config import SINERGIAS_FIJAS
+from collections import Counter
 
 
 # Asignar un número a cada héroe
@@ -47,8 +46,7 @@ def vectorizar_partida(nombre_archivo):
 
 from config import SINERGIAS_FIJAS
 from sinergias import datos_heroes
-from preparar_datos import heroes_id
-from collections import Counter
+
 
 def vector_entrada(estado):
     oro = estado["oro"]


### PR DESCRIPTION
## Summary
- remove self import of `heroes_id` in `preparar_datos.py`
- keep only `SINERGIAS_FIJAS` and `datos_heroes` imports near `vector_entrada`
- move `Counter` import to top level

## Testing
- `python test_vector.py`

------
https://chatgpt.com/codex/tasks/task_b_6859c12ebf4c8330b3804e3e5c0bc0c0