### PR TITLE
Add level to state vector

### DIFF
--- a/entrenar_con_todo.py
+++ b/entrenar_con_todo.py
@@ -25,7 +25,7 @@ for i, salida in enumerate(salidas):
             y[i, idx] = 1
 
 modelo = nn.Sequential(
-    nn.Linear(9 + len(SINERGIAS_FIJAS), 32),
+    nn.Linear(10 + len(SINERGIAS_FIJAS), 32),
     nn.ReLU(),
     nn.Linear(32, 5),
     nn.Sigmoid()

--- a/entrenar_con_varios.py
+++ b/entrenar_con_varios.py
@@ -29,7 +29,7 @@ for i, e in enumerate(ejemplos):
 
 # Modelo
 modelo = nn.Sequential(
-    nn.Linear(9 + len(SINERGIAS_FIJAS), 32),
+    nn.Linear(10 + len(SINERGIAS_FIJAS), 32),
     nn.ReLU(),
     nn.Linear(32, 5),
     nn.Sigmoid()

--- a/entrenar_modelo.py
+++ b/entrenar_modelo.py
@@ -31,7 +31,7 @@ def entrenar_modelo():
 
     # Red neuronal
     modelo = nn.Sequential(
-        nn.Linear(9 + len(SINERGIAS_FIJAS), 32),
+        nn.Linear(10 + len(SINERGIAS_FIJAS), 32),
         nn.ReLU(),
         nn.Linear(32, 5),
         nn.Sigmoid()

--- a/modelo_ia.py
+++ b/modelo_ia.py
@@ -8,7 +8,7 @@ from tienda_utils import tienda_presente
 
 # Red neuronal igual a la del entrenamiento
 modelo = nn.Sequential(
-    nn.Linear(9 + len(SINERGIAS_FIJAS), 32),
+    nn.Linear(10 + len(SINERGIAS_FIJAS), 32),
     nn.ReLU(),
     nn.Linear(32, 5),
     nn.Sigmoid()

--- a/preparar_datos.py
+++ b/preparar_datos.py
@@ -16,6 +16,7 @@ def vectorizar_partida(nombre_archivo):
 
     for ronda in datos:
         oro = ronda["oro_inicial"]
+        nivel = ronda.get("nivel", 0) or 0
         tienda = [heroes_id.get(h, 0) for h in ronda["tienda"]]
         tienda += [0] * (5 - len(tienda))  # relleno si hay menos de 5
 
@@ -30,7 +31,7 @@ def vectorizar_partida(nombre_archivo):
             if nombre in ronda_sinergias:
                 sinergias_vector[i] = ronda_sinergias[nombre]
 
-        entrada = [oro] + tienda + estrellas_vector + sinergias_vector
+        entrada = [oro, nivel] + tienda + estrellas_vector + sinergias_vector
 
         salida = []
 
@@ -49,7 +50,8 @@ from sinergias import datos_heroes
 
 
 def vector_entrada(estado):
-    oro = estado["oro"]
+    oro = estado.get("oro", 0) or 0
+    nivel = estado.get("nivel", 0) or 0
     tienda = [heroes_id.get(h, 0) for h in estado["tienda"]]
     tienda += [0] * (5 - len(tienda))  # asegurar que tenga 5 valores
 
@@ -78,4 +80,4 @@ def vector_entrada(estado):
             conteo[s] += 1
 
     vector_sinergias = list(conteo.values())
-    return [oro] + tienda + vector_estrellas + vector_sinergias
+    return [oro, nivel] + tienda + vector_estrellas + vector_sinergias

--- a/simulador.py
+++ b/simulador.py
@@ -97,7 +97,7 @@ if __name__ == "__main__":
     import os
 
     modelo = nn.Sequential(
-        nn.Linear(9 + len(SINERGIAS_FIJAS), 32),
+        nn.Linear(10 + len(SINERGIAS_FIJAS), 32),
         nn.ReLU(),
         nn.Linear(32, 5),
         nn.Sigmoid()


### PR DESCRIPTION
## Summary
- include player level in `vector_entrada` and `vectorizar_partida`
- adjust neural input sizes for training and inference scripts

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python test_vector.py > /tmp/test_vector.out && tail -n 10 /tmp/test_vector.out`

------
https://chatgpt.com/codex/tasks/task_b_6859c34287b883308af8c51e1f1fb9b0