### PR TITLE
Add auto restart on match end

### DIFF
--- a/fin_partida.py
+++ b/fin_partida.py
@@ -1,0 +1,22 @@
+import cv2
+import numpy as np
+import pytesseract
+
+import io_backend
+
+# Approximate region where the 'Victory' or 'Defeat' text appears
+# Coordinates: (x, y, width, height) for an 800x360 screenshot
+FIN_PARTIDA_REGION = (250, 100, 300, 80)
+
+
+def detectar_fin_partida() -> bool:
+    """Return True if the end-of-game screen is detected."""
+    captura = io_backend.screenshot()
+    if captura is None:
+        return False
+
+    x, y, w, h = FIN_PARTIDA_REGION
+    region = captura.crop((x, y, x + w, y + h))
+    gray = cv2.cvtColor(np.array(region), cv2.COLOR_RGB2GRAY)
+    texto = pytesseract.image_to_string(gray, config="--psm 7").lower()
+    return any(palabra in texto for palabra in ("victory", "defeat", "victoria", "derrota"))


### PR DESCRIPTION
## Summary
- detect victory/defeat screens
- automatically restart matches when detected
- integrate end-of-game detection into training loop

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_685ab8e1fa248330a724e5f5e671e63f