### PR TITLE
Improve error handling and logging

### DIFF
--- a/aprendizaje_continuo.py
+++ b/aprendizaje_continuo.py
@@ -1,7 +1,11 @@
 # aprendizaje_continuo.py
 import os
 import time
+import subprocess
+import logging
 from oro_autoentrenar import entrenar
+
+logging.basicConfig(level=logging.INFO)
 
 EJEMPLOS_ENTRENADOS = set()
 TIEMPO_ESPERA = 5  # segundos
@@ -10,19 +14,29 @@ def contar_ejemplos():
     return set(f for f in os.listdir("oro_dataset") if f.endswith(".png"))
 
 def main():
-    print("[🚀] Iniciando aprendizaje continuo...")
+    logging.info("[🚀] Iniciando aprendizaje continuo...")
     while True:
-        os.system("python mcgg_jake_runner.py")
+        try:
+            subprocess.run(["python", "mcgg_jake_runner.py"], check=True)
+        except subprocess.CalledProcessError as exc:
+            logging.error("mcgg_jake_runner.py failed: %s", exc)
+            continue
 
         nuevos = contar_ejemplos()
         diferencia = nuevos - EJEMPLOS_ENTRENADOS
 
         if len(diferencia) >= 10:
-            print(f"[📚] Se detectaron {len(diferencia)} ejemplos nuevos. Reentrenando...")
+            logging.info(
+                "[📚] Se detectaron %d ejemplos nuevos. Reentrenando...",
+                len(diferencia),
+            )
             entrenar()
             EJEMPLOS_ENTRENADOS.update(nuevos)
         else:
-            print(f"[⏳] Aún no hay suficientes nuevos ejemplos ({len(diferencia)}/10)")
+            logging.info(
+                "[⏳] Aún no hay suficientes nuevos ejemplos (%d/10)",
+                len(diferencia),
+            )
 
         time.sleep(TIEMPO_ESPERA)
 

--- a/detection.py
+++ b/detection.py
@@ -1,5 +1,8 @@
 import json
 import os
+import logging
+
+logging.basicConfig(level=logging.INFO)
 from typing import List, Tuple
 
 import numpy as np
@@ -31,16 +34,16 @@ def _load_hero_labels(annotations_file: str = "dataset/annotations.json") -> lis
                 for name in data["labels"].values():
                     if name not in LABELS.values() and name not in EXTRA_LABELS:
                         heroes.add(name)
-        except Exception:
-            pass
+        except Exception as exc:
+            logging.exception("Failed to load hero labels from %s", annotations_file)
 
     if not heroes:
         try:
             from sinergias import datos_heroes
 
             heroes.update(datos_heroes.keys())
-        except Exception:
-            pass
+        except Exception as exc:
+            logging.exception("Failed to import hero labels from sinergias: %s", exc)
 
     return sorted(heroes)
 

--- a/generar_reporte.py
+++ b/generar_reporte.py
@@ -2,6 +2,9 @@ import os
 import json
 import pandas as pd
 import matplotlib.pyplot as plt
+import logging
+
+logging.basicConfig(level=logging.INFO)
 
 
 def generar_reporte(archivo_datos="partida_simulada.json", winrate_log="winrate_por_ciclo.txt", salida_dir="graficas"):
@@ -21,7 +24,7 @@ def generar_reporte(archivo_datos="partida_simulada.json", winrate_log="winrate_
             plt.savefig(os.path.join(salida_dir, "winrate_trend.png"))
             plt.close()
         except Exception as e:
-            print(f"Error al generar grafico de winrate: {e}")
+            logging.error("Error al generar grafico de winrate: %s", e)
 
     # Synergy usage
     if os.path.exists(archivo_datos):
@@ -29,7 +32,7 @@ def generar_reporte(archivo_datos="partida_simulada.json", winrate_log="winrate_
             with open(archivo_datos, encoding="utf-8") as f:
                 datos = json.load(f)
         except Exception as e:
-            print(f"Error al leer {archivo_datos}: {e}")
+            logging.error("Error al leer %s: %s", archivo_datos, e)
             datos = []
 
         conteo = {}

--- a/io_backend.py
+++ b/io_backend.py
@@ -1,6 +1,9 @@
 import io
 import subprocess
 from PIL import Image
+import logging
+
+logging.basicConfig(level=logging.INFO)
 
 import config
 
@@ -33,10 +36,10 @@ def screenshot(region=None):
                 "-p",
             ], stdout=subprocess.PIPE, check=True)
         except FileNotFoundError:
-            print("[ADB ERROR] 'adb' command not found. Check your adb installation and connection.")
+            logging.error("[ADB ERROR] 'adb' command not found. Check your adb installation and connection.")
             return None
         except subprocess.CalledProcessError:
-            print("[ADB ERROR] Failed to capture screenshot. Ensure a device is connected and authorized.")
+            logging.error("[ADB ERROR] Failed to capture screenshot. Ensure a device is connected and authorized.")
             return None
         img = Image.open(io.BytesIO(result.stdout))
         if region:
@@ -63,11 +66,11 @@ def tap(x, y):
             ], check=True)
         except FileNotFoundError:
             msg = "[ADB ERROR] 'adb' command not found. Check your adb installation and connection."
-            print(msg)
+            logging.error(msg)
             raise ADBError(msg)
         except subprocess.CalledProcessError:
             msg = "[ADB ERROR] Failed to send tap command. Ensure a device is connected and authorized."
-            print(msg)
+            logging.error(msg)
             raise ADBError(msg)
     else:
         raise ValueError(f"Unsupported IO_MODE: {config.IO_MODE}")
@@ -94,11 +97,11 @@ def press(key: str):
             ], check=True)
         except FileNotFoundError:
             msg = "[ADB ERROR] 'adb' command not found. Check your adb installation and connection."
-            print(msg)
+            logging.error(msg)
             raise ADBError(msg)
         except subprocess.CalledProcessError:
             msg = "[ADB ERROR] Failed to send keyevent command. Ensure a device is connected and authorized."
-            print(msg)
+            logging.error(msg)
             raise ADBError(msg)
     else:
         raise ValueError(f"Unsupported IO_MODE: {config.IO_MODE}")

--- a/leer_estado_juego.py
+++ b/leer_estado_juego.py
@@ -6,6 +6,9 @@ from detectar_sinergias import detectar_sinergias_activas
 from detection import load_detector, detect_heroes, detect_level
 import io_backend
 import os
+import logging
+
+logging.basicConfig(level=logging.INFO)
 
 _detector = None
 _detector_mtime = None
@@ -34,21 +37,21 @@ def leer_estado_juego():
         estado["ronda"] = ronda
     except Exception as e:
         estado["ronda"] = None
-        print(f"[ERROR] No se pudo leer la ronda: {e}")
+        logging.error("[ERROR] No se pudo leer la ronda: %s", e)
 
     try:
         sinergias = detectar_sinergias_activas()
         estado["sinergias"] = sinergias
     except Exception as e:
         estado["sinergias"] = []
-        print(f"[ERROR] No se pudo leer las sinergias: {e}")
+        logging.error("[ERROR] No se pudo leer las sinergias: %s", e)
 
     try:
         oro = detectar_oro()
         estado["oro"] = oro
     except Exception as e:
         estado["oro"] = None
-        print(f"[ERROR] No se pudo leer el oro: {e}")
+        logging.error("[ERROR] No se pudo leer el oro: %s", e)
 
     # Detectar héroes en tienda y banco
     try:
@@ -68,7 +71,7 @@ def leer_estado_juego():
         estado.setdefault("tienda", [])
         estado.setdefault("banco", [])
         estado.setdefault("nivel", None)
-        print(f"[ERROR] No se pudieron detectar tienda/banco: {e}")
+        logging.error("[ERROR] No se pudieron detectar tienda/banco: %s", e)
 
     return estado
 
@@ -76,4 +79,4 @@ def leer_estado_juego():
 # Prueba directa
 if __name__ == "__main__":
     estado = leer_estado_juego()
-    print("Estado actual del juego:", estado)
+    logging.info("Estado actual del juego: %s", estado)

--- a/oro_autoentrenar.py
+++ b/oro_autoentrenar.py
@@ -3,6 +3,9 @@ import cv2
 import numpy as np
 from sklearn.neural_network import MLPRegressor
 import joblib
+import logging
+
+logging.basicConfig(level=logging.INFO)
 
 def cargar_datos_auto():
     X, y = [], []
@@ -15,7 +18,8 @@ def cargar_datos_auto():
             try:
                 label = int(archivo.split(".")[0])  # ej: 42.png -> 42
                 y.append(label)
-            except:
+            except ValueError as exc:
+                logging.warning("Invalid label in filename %s: %s", archivo, exc)
                 continue
     return np.array(X), np.array(y)
 
@@ -24,7 +28,7 @@ def entrenar():
     modelo = MLPRegressor(hidden_layer_sizes=(128,), max_iter=500)
     modelo.fit(X, y)
     joblib.dump(modelo, "modelo_oro.pkl")
-    print("[✓] Modelo actualizado")
+    logging.info("[✓] Modelo actualizado")
 
 if __name__ == "__main__":
     entrenar()

--- a/predecir_oro.py
+++ b/predecir_oro.py
@@ -1,6 +1,9 @@
 from PIL import Image
 import torch
 from torchvision import transforms
+import logging
+
+logging.basicConfig(level=logging.INFO)
 
 # Cargar el modelo entrenado una vez
 modelo = torch.load("modelo_oro.pt")
@@ -26,16 +29,16 @@ def predecir_oro(ruta_imagen):
         prediccion = salida.item()
         return int(round(prediccion)), prediccion
     except Exception as e:
-        print(f"[✗] Error al predecir oro: {e}")
+        logging.error("[✗] Error al predecir oro: %s", e)
         return -1, -1
 
 # Ejemplo de uso
 def main():
     oro, confianza = predecir_oro("frame_oro.png")
     if oro == -1:
-        print("[✗] Error al procesar la imagen.")
+        logging.error("[✗] Error al procesar la imagen.")
     else:
-        print(f"[✓] Oro detectado: {oro} (confianza: {confianza:.4f})")
+        logging.info("[✓] Oro detectado: %d (confianza: %.4f)", oro, confianza)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- replace `os.system` call with `subprocess.run` and error logging
- log failures when loading hero labels instead of silently ignoring them
- switch several scripts to use the `logging` module

## Testing
- `python -m py_compile aprendizaje_continuo.py detection.py generar_reporte.py io_backend.py leer_estado_juego.py oro_autoentrenar.py predecir_oro.py`
- `python test.py`
- `python test_vector.py`

------
https://chatgpt.com/codex/tasks/task_b_685abb33f2008330a99c4edc2a3a0fd6