### PR TITLE
Add autonomous training mode and improve loop

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -157,6 +157,9 @@ Con el tiempo, la IA **maximiza su recompensa**.
 4. Para habilitar el aprendizaje continuo ejecuta `python autoentrenar_detector.py`.
    Este proceso captura nuevas imágenes etiquetadas durante las partidas y
    reentrena periódicamente, reemplazando `detector.pth` sin intervención manual.
+5. Si deseas un ciclo totalmente autónomo (detector + agente DQN), ejecuta
+   `python entrenamiento_autonomo.py`. Este script inicia el capturador y el
+   bucle de entrenamiento para que el sistema juegue y aprenda sin supervisión.
 
 ---
 
@@ -181,7 +184,7 @@ Con el tiempo, la IA **maximiza su recompensa**.
 
 ## 📜 LICENCIA
 
-Este proyecto es de código abierto y experimental, compartido con fines educativos.
+Distribuido bajo la licencia MIT. Consulta el archivo `LICENSE` para más detalles.
 
 ---
 

--- a/entrenamiento_autonomo.py
+++ b/entrenamiento_autonomo.py
@@ -1,0 +1,23 @@
+"""Orquesta el entrenamiento completamente autonomo.
+
+Se lanza un hilo para el autoentrenamiento del detector mientras el bucle de
+``main_loop`` juega partidas y actualiza el agente DQN.
+"""
+
+from threading import Thread
+import autoentrenar_detector
+import main_loop
+
+
+def _run_detector():
+    autoentrenar_detector.main()
+
+
+def main() -> None:
+    detector_thread = Thread(target=_run_detector, daemon=True)
+    detector_thread.start()
+    main_loop.train_loop()
+
+
+if __name__ == "__main__":
+    main()

--- a/fin_partida.py
+++ b/fin_partida.py
@@ -9,14 +9,23 @@ import io_backend
 FIN_PARTIDA_REGION = (250, 100, 300, 80)
 
 
-def detectar_fin_partida() -> bool:
-    """Return True if the end-of-game screen is detected."""
+def detectar_fin_partida() -> tuple[bool, bool | None]:
+    """Return ``(fin, gano)`` based on OCR of the result text.
+
+    ``fin`` indica si se detectó la pantalla de fin de partida.
+    ``gano`` es ``True`` si se detecta una victoria, ``False`` si se detecta una
+    derrota y ``None`` en caso de que no se pueda determinar.
+    """
     captura = io_backend.screenshot()
     if captura is None:
-        return False
+        return False, None
 
     x, y, w, h = FIN_PARTIDA_REGION
     region = captura.crop((x, y, x + w, y + h))
     gray = cv2.cvtColor(np.array(region), cv2.COLOR_RGB2GRAY)
     texto = pytesseract.image_to_string(gray, config="--psm 7").lower()
-    return any(palabra in texto for palabra in ("victory", "defeat", "victoria", "derrota"))
+    if any(p in texto for p in ("victory", "victoria")):
+        return True, True
+    if any(p in texto for p in ("defeat", "derrota")):
+        return True, False
+    return False, None


### PR DESCRIPTION
## Summary
- detect match outcome in `fin_partida`
- integrate end-of-game handling and rewards in `main_loop`
- add new script `entrenamiento_autonomo.py` for full automation
- document the new workflow and provide MIT license

## Testing
- `python -m pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_b_685aa4de36dc8330bfc4be8a4a0830eb