### PR TITLE
Improve label mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,8 +145,20 @@ Con el tiempo, la IA **maximiza su recompensa**.
 ## 🎯 Entrenar el detector de objetos
 
 1. Coloca tus capturas anotadas en `dataset/images` y las
-   anotaciones en `dataset/annotations.json` (formato simple).
-   Ahora se admiten clases adicionales para **cada héroe en tienda**,
+   anotaciones en `dataset/annotations.json`.
+   Cada entrada debe tener el nombre de la imagen, las cajas y las
+   etiquetas por **nombre**:
+
+   ```json
+   {
+     "file": "ejemplo.png",
+     "boxes": [[10, 20, 60, 70]],
+     "labels": ["Layla"]
+   }
+   ```
+   El mapeo de nombres a IDs se genera automáticamente al entrenar, por lo
+   que puedes añadir nuevos héroes sin modificar el código.
+   También se admiten las clases para **cada héroe en tienda**,
    **las unidades del banco**, **el nivel del jugador** y objetos como
    cofres o ítems.
 2. Ejecuta `python detection.py` con la función `train_detector` para

--- a/autoentrenar_detector.py
+++ b/autoentrenar_detector.py
@@ -3,14 +3,13 @@ import time
 import json
 from pathlib import Path
 
-from detection import load_detector, detect, train_detector, LABELS
+from detection import load_detector, detect, train_detector
 import io_backend
 
 DATASET_DIR = Path("dataset/images")
 ANNOTATIONS_FILE = Path("dataset/annotations.json")
 TRAIN_INTERVAL = 60 * 30  # 30 minutos
 
-LABEL_TO_ID = {v: k for k, v in LABELS.items()}
 
 
 def guardar_captura(detector):
@@ -30,7 +29,7 @@ def guardar_captura(detector):
     sample = {
         "file": filename,
         "boxes": [box for _, box, _ in results],
-        "labels": [LABEL_TO_ID[label] for label, _, _ in results],
+        "labels": [label for label, _, _ in results],
     }
 
     if ANNOTATIONS_FILE.exists():

--- a/partida_simulada.json
+++ b/partida_simulada.json
@@ -1,0 +1,26 @@
+[
+  {
+    "ronda": 1,
+    "oro_inicial": 2,
+    "nivel": 1,
+    "tienda": ["Layla", "Saber", "Franco", "Bane", "Freya"],
+    "acciones": ["Comprar Layla"],
+    "gano": true,
+    "oro_ganado": 5,
+    "racha_actual": 1,
+    "tipo_racha": "victoria",
+    "sinergias": {"Tirador": 1}
+  },
+  {
+    "ronda": 2,
+    "oro_inicial": 5,
+    "nivel": 2,
+    "tienda": ["Franco", "Bane", "Karina", "Akai", "Layla"],
+    "acciones": [],
+    "gano": false,
+    "oro_ganado": 0,
+    "racha_actual": 1,
+    "tipo_racha": "derrota",
+    "sinergias": {"Tirador": 1}
+  }
+]


### PR DESCRIPTION
## Summary
- build dynamic label dictionary in `detection.py`
- support string labels in datasets
- capture labels by name in `autoentrenar_detector.py`
- document dataset JSON format in README
- add `partida_simulada.json` test data

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685ae2da3bb48330b5a2c3c28d9aae9f